### PR TITLE
Plugin base class improvements

### DIFF
--- a/src/plugins/legacy_plugin.cpp
+++ b/src/plugins/legacy_plugin.cpp
@@ -23,14 +23,6 @@
 #include <filesystem>
 #include <cassert>
 
-LegacyPlugin::LegacyPlugin()
-{
-}
-
-LegacyPlugin::~LegacyPlugin()
-{
-}
-
 bool LegacyPlugin::Init(char* parameter)
 {
 	return true;
@@ -65,11 +57,14 @@ const char* LegacyPlugin::GetPluginFullPath()
 void LegacyPlugin::SetPluginFullPath(std::string_view p)
 {
 	const auto fullPath = std::filesystem::path(p);
-	pluginFullPath = fullPath.string();
-
 	if (fullPath.has_stem())
 	{
+		pluginFullPath = fullPath.string();
 		pluginFileName = fullPath.stem().string();
+	}
+	else
+	{
+		throw std::runtime_error("SetPluginFullPath: input path has no stem.");
 	}
 }
 

--- a/src/plugins/legacy_plugin.h
+++ b/src/plugins/legacy_plugin.h
@@ -31,8 +31,13 @@
 class LegacyPlugin
 {
 public:
-	LegacyPlugin();
-	virtual ~LegacyPlugin();
+	LegacyPlugin() = default;
+	virtual ~LegacyPlugin() = default;
+
+	LegacyPlugin(const LegacyPlugin&) = delete;
+	LegacyPlugin& operator=(const LegacyPlugin&) = delete;
+	LegacyPlugin(LegacyPlugin&&) = delete;
+	LegacyPlugin& operator=(LegacyPlugin&&) = delete;
 
 	// Called when a plugin DLL gets loaded.
 	virtual bool Init(char*);

--- a/src/plugins/legacy_plugin.h
+++ b/src/plugins/legacy_plugin.h
@@ -21,12 +21,12 @@
 #if !defined(LEGACY_PLUGIN_H_INCLUDED)
 #define LEGACY_PLUGIN_H_INCLUDED
 
+#define NOMINMAX
 #include <windows.h>
 #include <string>
+#include <string_view>
 
 #define MAX_BUFFER 64*1024
-
-using namespace std;
 
 class LegacyPlugin
 {
@@ -41,29 +41,29 @@ public:
 	virtual const char* DoRequest(char *gameObject, char* request, char* parameters) = 0;
 
 	// Process query functions like GET_VERSION, ...
-	void ProcessQueryFunction(string function, char* buffer);
+	void ProcessQueryFunction(std::string_view function, char* buffer);
 
 	// Return the function class of the plugin in fClass
 	virtual void GetFunctionClass(char* fClass);
 
 	// Plugin file name functions
-	char* GetPluginFileName();
-	char* GetPluginFullPath();
-	void SetPluginFullPath(char* fileName);
+	const char* GetPluginFileName();
+	const char* GetPluginFullPath();
+	void SetPluginFullPath(std::string_view p);
 
 	// Copy a plugin response into the buffer provided by NWN
-	void nwnxcpy(char* buffer, const char* response);
+	void nwnxcpy(char* buffer, std::string_view response);
 	void nwnxcpy(char* buffer, const char* response, size_t len);
 
 protected:
-	string header;
-	string subClass;
-	string version;
-	string description;
+	std::string header;
+	std::string subClass;
+	std::string version;
+	std::string description;
 
 private:
-	char *pluginFileName;
-	char *pluginFullPath;
+	std::string pluginFileName;
+	std::string pluginFullPath;
 };
 
 #endif

--- a/src/plugins/plugin.cpp
+++ b/src/plugins/plugin.cpp
@@ -23,14 +23,6 @@
 #include <filesystem>
 #include <cassert>
 
-Plugin::Plugin()
-{
-}
-
-Plugin::~Plugin()
-{
-}
-
 bool Plugin::Init(char* parameter)
 {
 	return true;
@@ -67,11 +59,14 @@ const char* Plugin::GetPluginFullPath()
 void Plugin::SetPluginFullPath(std::string_view p)
 {
 	const auto fullPath = std::filesystem::path(p);
-	pluginFullPath = fullPath.string();
-
 	if (fullPath.has_stem())
 	{
+		pluginFullPath = fullPath.string();
 		pluginFileName = fullPath.stem().string();
+	}
+	else
+	{
+		throw std::runtime_error("SetPluginFullPath: input path has no stem.");
 	}
 }
 

--- a/src/plugins/plugin.h
+++ b/src/plugins/plugin.h
@@ -30,8 +30,13 @@
 class Plugin
 {
 public:
-	Plugin();
-	virtual ~Plugin();
+	Plugin() = default;
+	virtual ~Plugin() = default;
+
+	Plugin(const Plugin&) = delete;
+	Plugin& operator=(const Plugin&) = delete;
+	Plugin(Plugin&&) = delete;
+	Plugin& operator=(Plugin&&) = delete;
 
 	// Called when a plugin DLL gets loaded.
 	virtual bool Init(char*);

--- a/src/plugins/plugin.h
+++ b/src/plugins/plugin.h
@@ -20,12 +20,12 @@
 
 #pragma once
 
+#define NOMINMAX
 #include <windows.h>
 #include <string>
+#include <string_view>
 
 #define MAX_BUFFER 64*1024
-
-using namespace std;
 
 class Plugin
 {
@@ -41,32 +41,32 @@ public:
 	virtual void SetInt(char* sFunction, char* sParam1, int nParam2, int nValue) { return; }
 	virtual float GetFloat(char* sFunction, char* sParam1, int nParam2) { return 0.0; }
 	virtual void SetFloat(char* sFunction, char* sParam1, int nParam2, float fValue) { return; }
-	virtual char* GetString(char* sFunction, char* sParam1, int nParam2) { return NULL; }
+	virtual char* GetString(char* sFunction, char* sParam1, int nParam2) { return nullptr; }
 	virtual void SetString(char* sFunction, char* sParam1, int nParam2, char* sValue) { return; }
 
 	// Process query functions like GET_VERSION, ...
-	string ProcessQueryFunction(string function);
+	std::string ProcessQueryFunction(std::string_view function);
 
 	// Return the function class of the plugin in fClass
 	virtual void GetFunctionClass(char* fClass);
 
 	// Plugin file name functions
-	char* GetPluginFileName();
-	char* GetPluginFullPath();
-	void SetPluginFullPath(char* fileName);
+	const char* GetPluginFileName();
+	const char* GetPluginFullPath();
+	void SetPluginFullPath(std::string_view p);
 
 	// Copy a plugin response into the buffer provided by NWN
-	void nwnxcpy(char* buffer, const char* response);
+	void nwnxcpy(char* buffer, std::string_view response);
 	void nwnxcpy(char* buffer, const char* response, size_t len);
 
 protected:
-	string header;
-	string subClass;
-	string version;
-	string description;
-	char returnBuffer[MAX_BUFFER];
+	std::string header;
+	std::string subClass;
+	std::string version;
+	std::string description;
+	char returnBuffer[MAX_BUFFER] = {0};
 
 private:
-	char *pluginFileName;
-	char *pluginFullPath;
+	std::string pluginFileName;
+	std::string pluginFullPath;
 };


### PR DESCRIPTION
Changes:
- Fixed buffer overflow in nwnxcpy
- All data members are now initialized at construction
- Simplified SetPluginFullPath
- Made ProcessQueryFunction more efficient
- Removed "using namespace std" from plugin.h and legacy_plugin.h to prevent polluting global namespace

The changes only affect non-virtual methods so previously compiled plugins continue to work. The changes are also source compatible with plugins in the repository.