### PR TITLE
make xp_bugfix export its symbols

### DIFF
--- a/src/plugins/xp_bugfix/meson.build
+++ b/src/plugins/xp_bugfix/meson.build
@@ -13,6 +13,7 @@ shared_library('xp_bugfix',
     ],
     cpp_args: ['/permissive'],
     link_args: ['/dynamicbase', '/nxcompat'],
+    vs_module_defs: 'xp_bugfix.def',
     include_directories: include_dirs,
     dependencies: [
         cppcompiler.find_library('dbghelp'),

--- a/src/plugins/xp_objectattributes/xp_objectattributes.def
+++ b/src/plugins/xp_objectattributes/xp_objectattributes.def
@@ -1,4 +1,0 @@
-LIBRARY	"xp_objectattributes"
-
-EXPORTS
-


### PR DESCRIPTION
This caused an issue with xp_ServerExts failing to hook to xp_bugfix symbols, and potentially other plugins that depends on xp_bugfix