### PR TITLE
CI: Remove meson --backend=vs during setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       # Prepare build files
       - name: Meson Configure
         run: |
-          meson setup builddir --backend=vs --buildtype=release --optimization=2
+          meson setup builddir --buildtype=release --optimization=2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION
This shouldn't change anything, it's just a more standard / default way of building the project