### PR TITLE
Log file rotation & improvements

### DIFF
--- a/src/controller/nwnx.ini
+++ b/src/controller/nwnx.ini
@@ -1,6 +1,30 @@
 # NWNX4 configuration file
 # These are the default values for NWNX4.
 
+# Log verbosity
+# Messages from higher levels are always written. E.g. setting to 'info' will
+# also write 'error' and 'warning' messages.
+# Possible values: none, error, warning, info, debug, trace
+#
+# default: info
+log_level = info
+
+# Log file maximum size, before it is automatically rotated
+# Numbers can end with G M K for gigabytes, megabytes or kilobytes
+# 0 disables the log rotation
+#
+# default: 0
+log_max_file_size = 0
+
+# Buffer log writes.
+# This improves the performance of the logger, but you may lose some log lines
+# if the server crashes.
+# false = lines are flushed on every write
+# true  = lines are kept in memory and flushed when needed
+#
+# default: false
+log_buffered = false
+
 # List of all plugins to load when starting the NWN2Server process
 # The list is comma-separated, and each element must be either:
 # - A plugin name without the path extension. The associated DLL file must be

--- a/src/misc/ini.h
+++ b/src/misc/ini.h
@@ -25,6 +25,7 @@
 #ifndef INI_HPP
 #define INI_HPP
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <regex>
@@ -65,6 +66,21 @@ struct SimpleIniConfig {
 			} else if constexpr (std::is_same_v<T, char*>) {
 				*dest = valueStr;
 			} else {
+				// Allow true/false values for booleans
+				if constexpr (std::is_same_v<T, bool>) {
+					std::string lower(valueStr);
+					std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+					if (lower == "true") {
+						*dest = true;
+						return true;
+					}
+					if (lower == "false") {
+						*dest = false;
+						return true;
+					}
+				}
+
+				// Use stringstream default conversions
 				std::stringstream ss(valueStr);
 				T value;
 				ss >> value;

--- a/src/misc/log.cpp
+++ b/src/misc/log.cpp
@@ -37,15 +37,15 @@ LogLevel ParseLogLevel(const std::string& level)
 	std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
 	if (lower == "none")
 		return LogLevel::none;
-	if (lower == "err" || lower == "error")
+	else if (lower == "err" || lower == "error")
 		return LogLevel::error;
-	if (lower == "warn" || lower == "warning")
+	else if (lower == "warn" || lower == "warning")
 		return LogLevel::warning;
-	if (lower == "info" || lower == "information")
+	else if (lower == "info" || lower == "information")
 		return LogLevel::info;
-	if (lower == "dbg" || lower == "debug")
+	else if (lower == "dbg" || lower == "debug")
 		return LogLevel::debug;
-	if (lower == "trc" || lower == "trace")
+	else if (lower == "trc" || lower == "trace")
 		return LogLevel::trace;
 	return LogLevel::info;
 }
@@ -55,12 +55,13 @@ LogNWNX::LogNWNX(std::string filePath, LogLevel level)
 {
 	m_level = level;
 
-	if (m_level == LogLevel::none)
-		return;
-
-	m_ofStream.open(filePath, std::ofstream::out | std::ofstream::app);
-	if (!m_ofStream) {
-		std::cerr << "Canot open log file: " << filePath << std::endl;
+	if (m_level != LogLevel::none) {
+		// Open / create log file
+		m_ofPath = filePath;
+		m_ofStream.open(m_ofPath, std::ofstream::out | std::ofstream::app);
+		if (!m_ofStream) {
+			std::cerr << "Cannot open log file: " << m_ofPath << std::endl;
+		}
 	}
 }
 
@@ -70,11 +71,17 @@ void LogNWNX::Log(LogLevel level, const char* format, va_list a)
 		return;
 
 	auto t = time(nullptr);
-	char nowStr[22]; // 2021-04-24 13:37:05:
-	strftime(nowStr, 22, "%Y-%m-%d %H:%M:%S: ", localtime(&t));
+	char nowStr[26]; // 2022-10-09T19:48:01+0200
+	strftime(nowStr, 26, "%FT%T%z", localtime(&t));
+
+	// RFC 3339 compat fix
+	for (size_t i = 25; i > 22; i--)
+		nowStr[i] = nowStr[i - 1];
+	nowStr[22] = ':';
 
 	std::string fmt;
 	fmt += nowStr;
+	fmt += ": ";
 	switch (level) {
 		case LogLevel::error:
 			fmt += "ERROR: ";
@@ -99,9 +106,7 @@ void LogNWNX::Log(LogLevel level, const char* format, va_list a)
 	va_list args;
 	va_copy(args, a);
 	size_t len = std::vsnprintf(nullptr, 0, fmt.c_str(), args);
-	va_end(args);
 	std::vector<char> vec(len + 1);
-	va_copy(args, a);
 	std::vsnprintf(&vec[0], len + 1, fmt.c_str(), args);
 	va_end(args);
 	LogStr(&vec[0]);
@@ -110,10 +115,42 @@ void LogNWNX::Log(LogLevel level, const char* format, va_list a)
 void LogNWNX::LogStr(const char* message)
 {
 	if (m_ofStream.is_open()) {
+		if (m_maxFileSize > 0 && m_ofStream.tellp() > m_maxFileSize) {
+			RotateFile();
+		}
+
 		m_ofStream << message << std::endl;
-		m_ofStream.flush();
+		if (!m_buffered)
+			m_ofStream.flush();
 	} else {
 		std::cout << message << std::endl;
-		std::cout.flush();
+		if (!m_buffered)
+			std::cout.flush();
+	}
+}
+
+void LogNWNX::RotateFile()
+{
+	m_ofStream.close();
+
+	// Count number of rotated files
+	size_t freeSlot = 1;
+	while (std::filesystem::exists(m_ofPath.string() + "." + std::to_string(freeSlot))) {
+		freeSlot++;
+	}
+
+	// Move log.1 -> log.2
+	for (; freeSlot >= 2; freeSlot--) {
+		std::filesystem::rename(m_ofPath.string() + "." + std::to_string(freeSlot - 1),
+		                        m_ofPath.string() + "." + std::to_string(freeSlot));
+	}
+
+	// Move log -> log.1
+	std::filesystem::rename(m_ofPath, m_ofPath.string() + ".1");
+
+	// Reopen new log file
+	m_ofStream.open(m_ofPath, std::ofstream::out | std::ofstream::app);
+	if (!m_ofStream) {
+		std::cerr << "Cannot open log file: " << m_ofPath << std::endl;
 	}
 }

--- a/src/plugins/xp_bugfix/xp_bugfix.ini
+++ b/src/plugins/xp_bugfix/xp_bugfix.ini
@@ -1,9 +1,36 @@
 
 #
-# Amount of logs written to xp_bugfix.txt
-# 0=nothing, 1=only errors, 3=information, 5=debug and trace
+# Log verbosity
+# Messages from higher levels are always written. E.g. setting to 'info' will
+# also write 'error' and 'warning' messages.
+# Possible values: none, error, warning, info, debug, trace
 #
-loglevel = 3
+# default: info
+#
+
+log_level = info
+
+#
+# Log file maximum size, before it is automatically rotated
+# Numbers can end with G M K for gigabytes, megabytes or kilobytes
+# 0 disables the log rotation
+#
+# default: 0
+#
+
+log_max_file_size = 0
+
+#
+# Buffer log writes.
+# This improves the performance of the logger, but you may lose some log lines
+# if the server crashes.
+# false = lines are flushed on every write
+# true  = lines are kept in memory and flushed when needed
+#
+# default: false
+#
+
+log_buffered = false
 
 #
 # Swap out the server's NetLayer implementation (fix transition crash/hangs).
@@ -63,7 +90,7 @@ RewriteClientUdpPort = 1
 # The default value, which is also the server's built-in default, is
 # 200000 microseconds.  Values up to 400000 are often tolerable without too
 # much perceived impact to players.  Values over 1000000 often significantly
-# noticible to players.
+# noticeable to players.
 #
 # It is recommended that ReplaceNetLayer = 1 be used for this option, or area
 # load times for players may be greatly impacted.
@@ -73,7 +100,7 @@ RewriteClientUdpPort = 1
 
 #
 # The number of internal buffers used by the campaign database can be changed
-# here.  Each buffer utiizes 32K of memory.  The server default scales based
+# here.  Each buffer utilizes 32K of memory.  The server default scales based
 # on available memory, but can be inordinately large on machines with 4GB of
 # memory, up to 700MB.  The plugin default is 1024 buffers, for a maximum of
 # 32MB of memory used by the campaign database.
@@ -104,7 +131,7 @@ RewriteClientUdpPort = 1
 AIUpdateThrottle = 32
 
 #
-# Post fake WSAAsyncSelect completion window messages eacy main loop iteration
+# Post fake WSAAsyncSelect completion window messages each main loop iteration
 # if this is nonzero.  Defaults to 0.  DirectPollNetRecv is recommended instead
 # of this option.
 #
@@ -158,7 +185,7 @@ EnableTls = 1
 
 #
 # Enables large window size extensions, which require TLS support to be
-# effective.  This may improve performance for players on high altency
+# effective.  This may improve performance for players on high latency
 # connections.
 #
 # Default is 0.
@@ -192,7 +219,7 @@ InitialAreaAABBCount = 100
 
 #
 # Change the default attachment point allocation for game objects.  The
-# stock server default is 16, which is too many for objcts that do not have
+# stock server default is 16, which is too many for objects that do not have
 # any typical need for attachments, i.e. placed effects or environmental
 # objects.  Furthermore, only client applications appear to use anything
 # beyond the base attachment point, so it appears safe to set this value to

--- a/src/plugins/xp_mysql/xp_mysql.ini
+++ b/src/plugins/xp_mysql/xp_mysql.ini
@@ -10,6 +10,26 @@ schema   = nwnx
 # Default character set
 charset = utf8mb4
 
-# How much information should be written to xp_mysql.txt:
-# 0=nothing, 1=only errors, 3=everything
-loglevel = 3
+# Log verbosity
+# Messages from higher levels are always written. E.g. setting to 'info' will
+# also write 'error' and 'warning' messages.
+# Possible values: none, error, warning, info, debug, trace
+#
+# default: info
+log_level = info
+
+# Log file maximum size, before it is automatically rotated
+# Numbers can end with G M K for gigabytes, megabytes or kilobytes
+# 0 disables the log rotation
+#
+# default: 0
+log_max_file_size = 0
+
+# Buffer log writes.
+# This improves the performance of the logger, but you may lose some log lines
+# if the server crashes.
+# false = lines are flushed on every write
+# true  = lines are kept in memory and flushed when needed
+#
+# default: false
+log_buffered = false

--- a/src/plugins/xp_pickpocket/xp_pickpocket.ini
+++ b/src/plugins/xp_pickpocket/xp_pickpocket.ini
@@ -1,5 +1,29 @@
 class = PICK
 
+# Log verbosity
+# Messages from higher levels are always written. E.g. setting to 'info' will
+# also write 'error' and 'warning' messages.
+# Possible values: none, error, warning, info, debug, trace
+#
+# default: info
+log_level = info
+
+# Log file maximum size, before it is automatically rotated
+# Numbers can end with G M K for gigabytes, megabytes or kilobytes
+# 0 disables the log rotation
+#
+# default: 0
+log_max_file_size = 0
+
+# Buffer log writes.
+# This improves the performance of the logger, but you may lose some log lines
+# if the server crashes.
+# false = lines are flushed on every write
+# true  = lines are kept in memory and flushed when needed
+#
+# default: false
+log_buffered = false
+
 ; The script to execute when someone attempts a pickpocket. OBJECT_SELF will be the pickpocketter, and the
 ; the target can be retrieved with PickpocketGetTarget() from xp_inc_pickpocket include. PickpocketCancel()
 ; will disallow the action once the server returns.

--- a/src/plugins/xp_sqlite/xp_sqlite.ini
+++ b/src/plugins/xp_sqlite/xp_sqlite.ini
@@ -11,6 +11,26 @@ file = sqlite.db
 # Default: 0
 wrap_transaction = 0
 
-# How much information should be written to xp_sqlite.txt:
-# 0=nothing, 1=only errors, 2=warnings, 3=info, 4=debug
-loglevel = 3
+# Log verbosity
+# Messages from higher levels are always written. E.g. setting to 'info' will
+# also write 'error' and 'warning' messages.
+# Possible values: none, error, warning, info, debug, trace
+#
+# default: info
+log_level = info
+
+# Log file maximum size, before it is automatically rotated
+# Numbers can end with G M K for gigabytes, megabytes or kilobytes
+# 0 disables the log rotation
+#
+# default: 0
+log_max_file_size = 0
+
+# Buffer log writes.
+# This improves the performance of the logger, but you may lose some log lines
+# if the server crashes.
+# false = lines are flushed on every write
+# true  = lines are kept in memory and flushed when needed
+#
+# default: false
+log_buffered = false


### PR DESCRIPTION
ini config changes:
- Replaced `loglevel` with `log_level` (previous form is kept for compatibility, but no longer documented)
- Added `log_max_file_size` to enable log file rotation and set file max size
- Added `log_buffered` to avoid flushing log files on each log message