### PR TITLE
xp_bugfix: Allow RequestScript before InGameWorld

### DIFF
--- a/src/plugins/xp_bugfix/NetLayer.cpp
+++ b/src/plugins/xp_bugfix/NetLayer.cpp
@@ -1604,8 +1604,12 @@ OnNetLayerWindowReceive(
 	{
 		if (PlayerState[PlayerId].InGameWorld == false)
 		{
-			DebugPrint("Player %lu sent input before entering game world, dropped.\n", PlayerId);
-			return true;
+			//In this state, allow only run gui script
+			if (!(MajorFunction == CMD::Input && MinorFunction == 0x30))
+			{
+				DebugPrint("Player %lu sent input before entering game world, dropped.\n", PlayerId);
+				return true;
+			}
 		}
 
 		if (MajorFunction == CMD::Input)

--- a/src/plugins/xp_bugfix/NetLayer.cpp
+++ b/src/plugins/xp_bugfix/NetLayer.cpp
@@ -1604,7 +1604,15 @@ OnNetLayerWindowReceive(
 	{
 		if (PlayerState[PlayerId].InGameWorld == false)
 		{
-			//In this state, allow only run gui script
+			//
+			// In this state, allow only run gui script.
+			//
+			// In this current state, the Input.RunScript function can only be utilized effectively in 
+			// conjunction with other server plugins, as the player is currently represented as OBJECT_INVALID. 
+			//
+			// With the right processing, however, this makes it possible to obtain input from the client before
+			// he enters the GameWorld.
+			//
 			if (!(MajorFunction == CMD::Input && MinorFunction == 0x30))
 			{
 				DebugPrint("Player %lu sent input before entering game world, dropped.\n", PlayerId);


### PR DESCRIPTION
Allow Input.RequestScript  even before a player is InGameWorld. -> Don't cause issues and can be useful for advanced usage, such as authentication.